### PR TITLE
Keegan issue plottemp non-iteger index

### DIFF
--- a/pyhdust/__init__.py
+++ b/pyhdust/__init__.py
@@ -1136,7 +1136,7 @@ def plottemp(tfiles, philist=[0], interpol=False, xax=0, fmt=['png'],
             elif (xax == 2):
                 x = 1. - Rstar / x
                 xtitle = r'$1-R_*/r$'
-            y = data[3 + lev, :, ncmu / 2 + np + rplus, icphi]
+            y = data[3 + lev, :, ncmu // 2 + np + rplus, icphi]
             y = y / 1000.
             mk = 'o:'
             if rtfile.find('avg') > 0:


### PR DESCRIPTION
I followed Keegan's suggestion, substituting ncmu / 2 for ncmu // 2 in plottemp