### PR TITLE
pyfits (which is deprecated) was replaced by astropy.io.fits

### DIFF
--- a/pyhdust/__init__.py
+++ b/pyhdust/__init__.py
@@ -34,7 +34,7 @@ try:
     import matplotlib.patches as _mpatches
     from scipy import interpolate as _interpolate
     from scipy.interpolate import griddata as _griddata
-    import pyfits as _pf
+    import astropy.io.fits as _pf
 except ImportError:
     _warn.warn('# matplotlib, pyfits, six and/or scipy module not installed!!')
 

--- a/pyhdust/interftools.py
+++ b/pyhdust/interftools.py
@@ -46,9 +46,9 @@ try:
     import matplotlib.gridspec as _gridspec
     import matplotlib.ticker as _mtick
     from matplotlib.lines import Line2D as _Line2D
-    import pyfits as _pyfits
+    import astropy.io.fits as _pyfits
 except ImportError:
-    _warn.warn('matplotlib, six and/or pyfits module not installed!!!')
+    _warn.warn('matplotlib, six and/or astropy module not installed!!!')
 
 __author__ = "Daniel Moser"
 __email__ = "dmfaes@gmail.com"

--- a/pyhdust/oifits.py
+++ b/pyhdust/oifits.py
@@ -85,9 +85,9 @@ import numbers as _numbers
 import warnings as _warn
 
 try:
-    import pyfits as _pyfits
+    import astropy.io.fits as _pyfits
 except ImportError:
-    _warn.warn('pyfits module not installed!!!')
+    _warn.warn('astropy module not installed!!!')
 
 __author__ = "Paul Boley"
 __email__ = "boley@mpia-hd.mpg.de"

--- a/pyhdust/poltools.py
+++ b/pyhdust/poltools.py
@@ -38,14 +38,14 @@ def eprint(*args, **kwargs):
 try:
     import matplotlib.pyplot as _plt
     from matplotlib.transforms import offset_copy as _offset_copy
-    import pyfits as _pyfits
+    import astropy.io.fits as _pyfits
     from scipy.optimize import curve_fit as _curve_fit
     from scipy.integrate import simps as _simps
     from scipy.interpolate import interp1d as _interp1d
     import matplotlib as _mpl
     _mpl.rcParams['pdf.fonttype']=42
 except ImportError:
-    eprint('# Warning! matplotlib and/or pyfits module not installed!!!')
+    eprint('# Warning! matplotlib and/or astropy and/or scipy module not installed!!!')
 
 __author__ = "Daniel Moser"
 __email__ = "dmfaes@gmail.com"

--- a/pyhdust/spectools.py
+++ b/pyhdust/spectools.py
@@ -34,7 +34,7 @@ import warnings as _warn
 # from lmfit import Model as _Model
 
 try:    
-    import pyfits as _pyfits
+    import astropy.io.fits as _pyfits
     import matplotlib as _mpl
     import matplotlib.pyplot as _plt
     import matplotlib.patches as _mpatches
@@ -45,7 +45,7 @@ try:
     from astropy.modeling import models as _models
     from astropy.modeling import fitting as _fitting
 except ImportError:
-    _warn.warn('matplotlib, scipy, and/or astropy module not installed!!!')
+    _warn.warn('matplotlib and/or scipy and/or astropy module not installed!!!')
 
 try:
     import pyqt_fit.nonparam_regression as _smooth


### PR DESCRIPTION
pyfits replaced by astropy.io.fits, to correct deprecation warning regarding the former