### PR TITLE
onlyfilters option fixed in mergesed2

### DIFF
--- a/pyhdust/__init__.py
+++ b/pyhdust/__init__.py
@@ -576,10 +576,10 @@ def mergesed2(models, Vrots, path=None, checklineval=False, onlyfilters=None):
         else:
             lsed2 = []
             for f in onlyfilters:
-                pattern = _os.path.join(modfld, '{0}'.format(f), 
+                pattern = _os.path.join(modfld, '{0}'.format(f) +
                     '*{0}.sed2'.format(modelname[:-4]))
                 lsed2.extend(_glob(pattern))
-                pattern = _os.path.join(modfld, '{0}'.format(f), 
+                pattern = _os.path.join(modfld, '{0}'.format(f) +
                     '*{0}_SEI.sed2'.format(modelname[:-4]))
                 lsed2.extend(_glob(pattern))
         # print lsed2, '{0}*{1}*.sed2'.format(modfld, modelname[:-4])


### PR DESCRIPTION
For onlyfilters!=None, no sed2 files were found by pyhdust.mergesed2 routine, and therefore no fullsed files were generated. This happened because the code placed a '/' character just after the HDUST band suffix. In this fix, the '/' inclusion was suppressed.