### PR TITLE
Missing break statement in sed2info

### DIFF
--- a/pyhdust/__init__.py
+++ b/pyhdust/__init__.py
@@ -81,6 +81,7 @@ def sed2info(sfile):
     while info == "":
         if fcont[i][0] != "%":
             info = _np.array(fcont[i].split(), dtype=float)
+            break
         i += 1
     return info
 


### PR DESCRIPTION
This PR adds a missing break statement when reading info from file in sed2info.